### PR TITLE
For better theme integrations, switch to using builtin notifications icons

### DIFF
--- a/donotdisturb-button@nls1729/extension.js
+++ b/donotdisturb-button@nls1729/extension.js
@@ -32,8 +32,8 @@ const PanelMenu = imports.ui.panelMenu;
 const GnomeSession = imports.misc.gnomeSession;
 const Mainloop = imports.mainloop;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const BUSY = Me.path + '/available-no.png'
-const AVAILABLE = Me.path + '/available-yes.png'
+const BUSY='notifications-disabled-symbolic';
+const AVAILABLE = 'notifications-symbolic';
 const SHORTCUT = 'shortcut';
 
 const DoNotDisturbButton = new Lang.Class({


### PR DESCRIPTION
This PR change the icons to notifications-symbolic and notifications-disabled…-symbolic so it fits better with various themes. I am hoping this makes sense to you :-D