### PR TITLE
fix error on opening convenience in GS 3.34

### DIFF
--- a/activities-config/extension.js
+++ b/activities-config/extension.js
@@ -43,7 +43,6 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
 const Colors = Me.imports.colors;
-const Convenience = Me.imports.convenience;
 const Keys = Me.imports.keys;
 const Notify = Me.imports.notify;
 const Readme = Me.imports.readme;
@@ -241,7 +240,7 @@ class Configurator {
         let schemaObj = schemaSource.lookup(THEME_SCHEMA, true);
         if (schemaObj)
             this._themeSettings = new Gio.Settings({ settings_schema: schemaObj });
-        this._settings = Convenience.getSettings();
+        this._settings = ExtensionUtils.getSettings();
         this._firstEnable = this._settings.get_boolean(Keys.FIRST_ENABLE);
         if (this._firstEnable)
             this._settings.set_string(Keys.NEW_ICO, DEFAULT_ICO);
@@ -1192,6 +1191,6 @@ function _overviewToggler() {
 }
 
 function init(metadata) {
-    Convenience.initTranslations();
+    ExtensionUtils.initTranslations();
     return new Configurator();
 }

--- a/activities-config/prefs.js
+++ b/activities-config/prefs.js
@@ -31,7 +31,6 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
-const Convenience = Me.imports.convenience;
 const Keys = Me.imports.keys;
 const Readme = Me.imports.readme;
 const GioSSS = Gio.SettingsSchemaSource;
@@ -41,7 +40,7 @@ const COMMIT = "Commit: ";
 const TILE_OFF = 'tile-max-effect-off';
 
 function init() {
-    Convenience.initTranslations();
+    ExtensionUtils.initTranslations();
 }
 
 const ActivitiesConfiguratorSettingsWidget = GObject.registerClass(
@@ -50,7 +49,7 @@ class ActivitiesConfiguratorSettingsWidget extends Gtk.Grid {
     _init(params) {
         super._init(params)
 
-        this._settings = Convenience.getSettings();
+        this._settings = ExtensionUtils.getSettings();
         let version = '[ v' + this._settings.get_string(Keys.EPVERSION) +
             ' GS ' + this._settings.get_string(Keys.GSPVERSION) + ' ]';
 


### PR DESCRIPTION
The activities-config extension has dependency on convenience.js, which
is provided by gnome-shell-extension. However, the file convenience.js
has been removed in gnome-shell-extension 3.34, which results an error
on loading this extension.

Signed-off-by: Hanfeng Qin <hanfengtsin@gmail.com>